### PR TITLE
add CheckResponse for Client to check the response

### DIFF
--- a/cmd/ping/main.go
+++ b/cmd/ping/main.go
@@ -93,6 +93,7 @@ func main() {
 	}
 
 	req := ping.Request{
+		ID:   os.Getpid(),
 		Dst:  net.ParseIP(host.String()),
 		Src:  net.ParseIP(getAddr(*iface)),
 		Data: data,

--- a/ping.go
+++ b/ping.go
@@ -50,10 +50,19 @@ type Response struct {
 }
 
 // Client is a ping client.
-type Client struct{}
+type Client struct {
+	// CheckResponse checks whether the response is valid.
+	CheckResponse func(*Response) bool
+}
 
 // DefaultClient is the default client used by Do.
-var DefaultClient = &Client{}
+var DefaultClient = &Client{CheckResponse: CheckResponse}
+
+// CheckResponse checks whether the id and the seq are equal respectively
+// between request and response.
+func CheckResponse(resp *Response) bool {
+	return resp.ID == resp.Req.ID && int(resp.Seq) == resp.Req.Seq
+}
 
 // NewRequest resolves dst as an IPv4 address and returns a pointer to a request
 // using that as the destination.
@@ -118,14 +127,13 @@ func (c *Client) Do(ctx context.Context, req *Request) (*Response, error) {
 		return nil, err
 	}
 
-	resp, readErr = read(ctx, conn)
+	resp, readErr = read(ctx, conn, req, c.CheckResponse)
 	if readErr != nil {
 		return nil, readErr
 	}
 
 	resp.RTT = resp.rcvdAt.Sub(sentAt)
 	req.sentAt = sentAt
-	resp.Req = req
 
 	if readErr != nil {
 		return nil, readErr
@@ -199,18 +207,20 @@ func (req *Request) proto() int {
 	return protocolIPv4ICMP
 }
 
-func read(ctx context.Context, conn *icmp.PacketConn) (*Response, error) {
+func read(ctx context.Context, conn *icmp.PacketConn, req *Request,
+	check func(*Response) bool) (*Response, error) {
 	if c4 := conn.IPv4PacketConn(); c4 != nil {
-		return read4(ctx, c4)
+		return read4(ctx, c4, req, check)
 	}
 	c6 := conn.IPv6PacketConn()
 	if c6 == nil {
 		return nil, errors.New("bad icmp connection type")
 	}
-	return read6(ctx, c6)
+	return read6(ctx, c6, req, check)
 }
 
-func read4(ctx context.Context, conn *ipv4.PacketConn) (*Response, error) {
+func read4(ctx context.Context, conn *ipv4.PacketConn, req *Request,
+	check func(*Response) bool) (*Response, error) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -261,7 +271,8 @@ func read4(ctx context.Context, conn *ipv4.PacketConn) (*Response, error) {
 
 			srcHost, _, _ := net.SplitHostPort(src.String())
 			dstHost, _, _ := net.SplitHostPort(conn.LocalAddr().String())
-			return &Response{
+			resp := &Response{
+				Req:         req,
 				ID:          id,
 				Seq:         seq,
 				Data:        bytesReceived[:n],
@@ -270,12 +281,16 @@ func read4(ctx context.Context, conn *ipv4.PacketConn) (*Response, error) {
 				Dst:         net.ParseIP(dstHost),
 				TTL:         ttl,
 				rcvdAt:      rcv,
-			}, nil
+			}
+			if check == nil || check(resp) {
+				return resp, nil
+			}
 		}
 	}
 }
 
-func read6(ctx context.Context, conn *ipv6.PacketConn) (*Response, error) {
+func read6(ctx context.Context, conn *ipv6.PacketConn, req *Request,
+	check func(*Response) bool) (*Response, error) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -326,7 +341,8 @@ func read6(ctx context.Context, conn *ipv6.PacketConn) (*Response, error) {
 
 			srcHost, _, _ := net.SplitHostPort(src.String())
 			dstHost, _, _ := net.SplitHostPort(conn.LocalAddr().String())
-			return &Response{
+			resp := &Response{
+				Req:         req,
 				ID:          id,
 				Seq:         seq,
 				Data:        bytesReceived[:n],
@@ -335,7 +351,10 @@ func read6(ctx context.Context, conn *ipv6.PacketConn) (*Response, error) {
 				Dst:         net.ParseIP(dstHost),
 				TTL:         ttl,
 				rcvdAt:      rcv,
-			}, nil
+			}
+			if check == nil || check(resp) {
+				return resp, nil
+			}
 		}
 	}
 }

--- a/ping.go
+++ b/ping.go
@@ -269,8 +269,16 @@ func read4(ctx context.Context, conn *ipv4.PacketConn, req *Request,
 				ttl = cm.TTL
 			}
 
-			srcHost, _, _ := net.SplitHostPort(src.String())
-			dstHost, _, _ := net.SplitHostPort(conn.LocalAddr().String())
+			srcHost, _, err := net.SplitHostPort(src.String())
+			if err != nil {
+				srcHost = src.String()
+			}
+
+			dstHost, _, err := net.SplitHostPort(conn.LocalAddr().String())
+			if err != nil {
+				dstHost = conn.LocalAddr().String()
+			}
+
 			resp := &Response{
 				Req:         req,
 				ID:          id,
@@ -339,8 +347,16 @@ func read6(ctx context.Context, conn *ipv6.PacketConn, req *Request,
 				ttl = cm.HopLimit
 			}
 
-			srcHost, _, _ := net.SplitHostPort(src.String())
-			dstHost, _, _ := net.SplitHostPort(conn.LocalAddr().String())
+			srcHost, _, err := net.SplitHostPort(src.String())
+			if err != nil {
+				srcHost = src.String()
+			}
+
+			dstHost, _, err := net.SplitHostPort(conn.LocalAddr().String())
+			if err != nil {
+				dstHost = conn.LocalAddr().String()
+			}
+
 			resp := &Response{
 				Req:         req,
 				ID:          id,

--- a/ping.go
+++ b/ping.go
@@ -117,27 +117,18 @@ func (c *Client) Do(ctx context.Context, req *Request) (*Response, error) {
 		}
 	}
 
-	var (
-		resp    *Response
-		readErr error
-	)
-
 	sentAt, err := send(ctx, conn, req)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, readErr = read(ctx, conn, req, c.CheckResponse)
-	if readErr != nil {
-		return nil, readErr
+	resp, err := read(ctx, conn, req, c.CheckResponse)
+	if err != nil {
+		return nil, err
 	}
 
 	resp.RTT = resp.rcvdAt.Sub(sentAt)
 	req.sentAt = sentAt
-
-	if readErr != nil {
-		return nil, readErr
-	}
 
 	return resp, nil
 }

--- a/ping_test.go
+++ b/ping_test.go
@@ -49,6 +49,8 @@ func testClient(t *testing.T, wg *sync.WaitGroup, req *ping.Request) {
 }
 
 func TestE2E(t *testing.T) {
+	c := &ping.Client{}
+
 	hostIPs := []string{"8.8.8.8", "8.8.4.4", "1.1.1.1"}
 	count := 3
 	deadline := time.Second * 5
@@ -84,7 +86,7 @@ func TestE2E(t *testing.T) {
 					wg.Add(1)
 					go func(seq int) {
 						defer wg.Done()
-						resp, err := ping.DefaultClient.Do(ctx, &ping.Request{
+						resp, err := c.Do(ctx, &ping.Request{
 							Dst: net.ParseIP(host),
 							Seq: seq,
 						})


### PR DESCRIPTION
The socket `SOCK_RAW` only returns the response packets by the destination ip. So it will receive all the ICMP responses. If pinging a site concurrently, the request ids of which are not the same, the `ID` and the `Seq` of response may not be the same as those of request.

However, we can add a function/method for `Client` to check and to filter them until receiving the right response. Of course, we can set it to `nil` to receiving all the response, but only the first is returned as the response.